### PR TITLE
Fixed David's title to include Lead

### DIFF
--- a/src/pages/ContactPage/ContactPage.jsx
+++ b/src/pages/ContactPage/ContactPage.jsx
@@ -61,7 +61,7 @@ const ContactPage = ({ user, setUser }) => {
               <label id='contact-label'>
                 <a href ='https://www.linkedin.com/in/daveuxui/'>
                   David Bieschke 
-                </a><br />UX/UI Designer
+                </a><br />UX/UI Designer Lead
               </label>
             </div>
             <div>


### PR DESCRIPTION
Looking at the site, I noticed David's title was never updated. Changed from "UX/UI Design" to "UX/UI Design Lead".